### PR TITLE
fix: Supabase接続設定を新しいConnection Pooling形式に対応

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -3,8 +3,9 @@ generator client {
 }
 
 datasource db {
-  provider = "postgresql"
-  url      = env("DATABASE_URL")
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DIRECT_URL")
 }
 
 model EarthquakeEventLog {


### PR DESCRIPTION
- prisma/schema.prismaにdirectUrl設定を追加
- DATABASE_URL: Transaction mode（ポート6543、Connection Pooling）
- DIRECT_URL: Session mode（ポート5432、マイグレーション専用）
- DEPLOYMENT.mdに正しい接続URL形式を記載
- GitHub ActionsではSession mode（ポート5432）を使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)