### PR TITLE
feat: パスワードリセット機能を実装

### DIFF
--- a/dist/src/app/lib/slack/messageBuilder.js
+++ b/dist/src/app/lib/slack/messageBuilder.js
@@ -45,12 +45,12 @@ function buildEarthquakeNotificationMessage(earthquake, departments, template) {
             .map((obs) => `${obs.prefecture}: 震度${obs.maxIntensity}`)
             .join("\n")
         : "情報なし";
-    // 部署ボタンを生成
+    // 部署ボタンを生成（絵文字のみ）
     const departmentButtons = departments.map((dept) => ({
         type: "button",
         text: {
             type: "plain_text",
-            text: `${dept.slackEmoji} ${dept.name}`,
+            text: dept.slackEmoji,
             emoji: true,
         },
         style: getButtonStyle(dept.buttonColor),
@@ -158,12 +158,12 @@ function buildUpdatedMessageWithStats(originalMessage, stats) {
  * @returns Slack Block Kit形式のメッセージ
  */
 function buildTrainingNotificationMessage(departments, template) {
-    // 部署ボタンを生成（本番と同じaction_idプレフィックスを使用）
+    // 部署ボタンを生成（絵文字のみ）
     const departmentButtons = departments.map((dept) => ({
         type: "button",
         text: {
             type: "plain_text",
-            text: `${dept.slackEmoji} ${dept.name}`,
+            text: dept.slackEmoji,
             emoji: true,
         },
         style: getButtonStyle(dept.buttonColor),

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -83,6 +83,13 @@ SLACK_SIGNING_SECRET=本番Slackアプリのsigning secret
 # Slack Bot Token暗号化キー（openssl rand -base64 32 で生成）
 SLACK_TOKEN_ENCRYPTION_KEY=生成した32バイトキー
 
+# SMTP設定（お名前.com）- パスワードリセット・招待メール送信に必要
+SMTP_HOST=mail1042.onamae.ne.jp
+SMTP_PORT=465
+SMTP_USER=noreply@anpikakunin.xyz
+SMTP_PASSWORD=[お名前.comメールパスワード]
+SMTP_FROM_EMAIL=noreply@anpikakunin.xyz
+
 # Node環境
 NODE_ENV=production
 ```

--- a/prisma/migrations/20251012163024_add_password_reset_token/migration.sql
+++ b/prisma/migrations/20251012163024_add_password_reset_token/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "password_reset_tokens" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "token" TEXT NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "used" BOOLEAN NOT NULL DEFAULT false,
+    "used_at" TIMESTAMP(3),
+
+    CONSTRAINT "password_reset_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "password_reset_tokens_token_key" ON "password_reset_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_token_idx" ON "password_reset_tokens"("token");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_user_id_idx" ON "password_reset_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "password_reset_tokens_expires_at_idx" ON "password_reset_tokens"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "password_reset_tokens" ADD CONSTRAINT "password_reset_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -203,6 +203,7 @@ model User {
   groupMemberships UserGroupMembership[]
   permissionAttachments UserPermissionAttachment[]
   activityLogs  ActivityLog[]
+  passwordResetTokens PasswordResetToken[]
 
   @@map("users")
 }
@@ -550,4 +551,23 @@ model TrainingConfirmationResponse {
   @@index([slackUserId])
   @@index([departmentId])
   @@index([respondedAt(sort: Desc)])
+}
+
+// パスワードリセットトークン
+model PasswordResetToken {
+  id        String   @id @default(uuid())
+  userId    String   @map("user_id")
+  token     String   @unique
+  expiresAt DateTime @map("expires_at")
+  createdAt DateTime @default(now()) @map("created_at")
+  used      Boolean  @default(false)
+  usedAt    DateTime? @map("used_at")
+
+  // リレーション
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@map("password_reset_tokens")
+  @@index([token])
+  @@index([userId])
+  @@index([expiresAt])
 }

--- a/src/app/api/auth/password-reset/request/route.ts
+++ b/src/app/api/auth/password-reset/request/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { prisma } from "@/app/lib/db/prisma";
+import { sendEmail } from "@/app/lib/email/mailer";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { email } = body;
+
+    if (!email) {
+      return NextResponse.json(
+        { error: "メールアドレスを入力してください" },
+        { status: 400 }
+      );
+    }
+
+    // ユーザーを検索
+    const user = await prisma.user.findUnique({
+      where: { email: email.toLowerCase().trim() },
+    });
+
+    // セキュリティのため、ユーザーが存在しない場合も成功レスポンスを返す
+    // （メールアドレスの存在確認を防ぐ）
+    if (!user) {
+      return NextResponse.json({
+        success: true,
+        message: "パスワードリセットメールを送信しました。メールをご確認ください。",
+      });
+    }
+
+    // 既存の未使用トークンを無効化
+    await prisma.passwordResetToken.updateMany({
+      where: {
+        userId: user.id,
+        used: false,
+      },
+      data: {
+        used: true,
+        usedAt: new Date(),
+      },
+    });
+
+    // 新しいトークンを生成（32バイト = 64文字のhex）
+    const token = crypto.randomBytes(32).toString("hex");
+
+    // トークンの有効期限（1時間）
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + 1);
+
+    // トークンをDBに保存
+    await prisma.passwordResetToken.create({
+      data: {
+        userId: user.id,
+        token,
+        expiresAt,
+      },
+    });
+
+    // リセットリンクを生成
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:8080";
+    const resetUrl = `${baseUrl}/reset-password?token=${token}`;
+
+    // メール送信
+    await sendEmail({
+      to: user.email,
+      subject: "パスワードリセットのご案内 - 安否確認システム",
+      html: `
+        <h2>パスワードリセットのご案内</h2>
+        <p>${user.email} 様</p>
+        <p>パスワードリセットのリクエストを受け付けました。</p>
+        <p>以下のリンクをクリックして、新しいパスワードを設定してください：</p>
+        <p><a href="${resetUrl}">${resetUrl}</a></p>
+        <p><strong>このリンクの有効期限は1時間です。</strong></p>
+        <p>このリクエストに心当たりがない場合は、このメールを無視してください。</p>
+        <hr>
+        <p style="font-size: 12px; color: #666;">
+          このメールは安否確認システムから自動送信されています。<br>
+          返信はできませんのでご了承ください。
+        </p>
+      `,
+    });
+
+    return NextResponse.json({
+      success: true,
+      message: "パスワードリセットメールを送信しました。メールをご確認ください。",
+    });
+  } catch (error) {
+    console.error("Password reset request error:", error);
+    return NextResponse.json(
+      { error: "パスワードリセットメールの送信に失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/auth/password-reset/reset/route.ts
+++ b/src/app/api/auth/password-reset/reset/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/app/lib/db/prisma";
+import { hashPassword, validatePasswordStrength } from "@/app/lib/auth/password";
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { token, password } = body;
+
+    if (!token) {
+      return NextResponse.json(
+        { error: "トークンが指定されていません" },
+        { status: 400 }
+      );
+    }
+
+    if (!password) {
+      return NextResponse.json(
+        { error: "新しいパスワードを入力してください" },
+        { status: 400 }
+      );
+    }
+
+    // パスワード強度チェック
+    const validation = validatePasswordStrength(password);
+    if (!validation.valid) {
+      return NextResponse.json(
+        { error: validation.errors.join("\n") },
+        { status: 400 }
+      );
+    }
+
+    // トークンを検証
+    const resetToken = await prisma.passwordResetToken.findUnique({
+      where: { token },
+      include: { user: true },
+    });
+
+    if (!resetToken) {
+      return NextResponse.json(
+        { error: "無効なリセットリンクです" },
+        { status: 400 }
+      );
+    }
+
+    // トークンが使用済みか確認
+    if (resetToken.used) {
+      return NextResponse.json(
+        { error: "このリセットリンクは既に使用されています" },
+        { status: 400 }
+      );
+    }
+
+    // トークンの有効期限確認
+    if (new Date() > resetToken.expiresAt) {
+      return NextResponse.json(
+        { error: "リセットリンクの有効期限が切れています。再度リクエストしてください。" },
+        { status: 400 }
+      );
+    }
+
+    // パスワードをハッシュ化
+    const passwordHash = await hashPassword(password);
+
+    // トランザクションでパスワード更新とトークン無効化
+    await prisma.$transaction([
+      // パスワード更新
+      prisma.user.update({
+        where: { id: resetToken.userId },
+        data: { passwordHash },
+      }),
+      // トークンを使用済みにマーク
+      prisma.passwordResetToken.update({
+        where: { id: resetToken.id },
+        data: {
+          used: true,
+          usedAt: new Date(),
+        },
+      }),
+    ]);
+
+    return NextResponse.json({
+      success: true,
+      message: "パスワードが正常にリセットされました。ログイン画面からログインしてください。",
+    });
+  } catch (error) {
+    console.error("Password reset error:", error);
+    return NextResponse.json(
+      { error: "パスワードリセットに失敗しました" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import toast, { Toaster } from "react-hot-toast";
+
+export default function ForgotPasswordPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/auth/password-reset/request", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ email }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "メールの送信に失敗しました");
+      }
+
+      setSubmitted(true);
+      toast.success(data.message || "パスワードリセットメールを送信しました");
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "メールの送信に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (submitted) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <Toaster position="top-right" />
+        <div className="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-md">
+          <div className="text-center">
+            <div className="mb-4 text-green-500 text-5xl">✓</div>
+            <h1 className="text-2xl font-bold text-white mb-4">
+              メールを送信しました
+            </h1>
+            <p className="text-gray-300 mb-6">
+              {email} 宛にパスワードリセットのメールを送信しました。
+              <br />
+              メールに記載されたリンクをクリックして、新しいパスワードを設定してください。
+            </p>
+            <p className="text-sm text-gray-400 mb-6">
+              ※ メールが届かない場合は、迷惑メールフォルダをご確認ください。
+            </p>
+            <button
+              onClick={() => router.push("/login")}
+              className="text-blue-400 hover:text-blue-300 hover:underline"
+            >
+              ログイン画面に戻る
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900">
+      <Toaster position="top-right" />
+      <div className="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-md">
+        <h1 className="text-2xl font-bold text-white mb-2 text-center">
+          パスワードの再発行
+        </h1>
+        <p className="text-gray-400 text-sm mb-6 text-center">
+          登録されているメールアドレスを入力してください
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              メールアドレス
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="your@email.com"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white font-medium py-2 px-4 rounded transition-colors"
+          >
+            {loading ? "送信中..." : "リセットメールを送信"}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <a
+            href="/login"
+            className="text-sm text-blue-400 hover:text-blue-300 hover:underline"
+          >
+            ログイン画面に戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/lib/email/mailer.ts
+++ b/src/app/lib/email/mailer.ts
@@ -1,0 +1,52 @@
+/**
+ * 汎用メール送信ライブラリ
+ */
+
+import nodemailer from "nodemailer";
+
+const FROM_EMAIL = process.env.SMTP_FROM_EMAIL || "noreply@anpikakunin.xyz";
+
+// お名前.com SMTPトランスポーター
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST || "mail1042.onamae.ne.jp",
+  port: parseInt(process.env.SMTP_PORT || "465"),
+  secure: process.env.SMTP_PORT === "465", // 465ならtrue、587ならfalse
+  auth: {
+    user: process.env.SMTP_USER || "noreply@anpikakunin.xyz",
+    pass: process.env.SMTP_PASSWORD || "",
+  },
+});
+
+export interface SendEmailParams {
+  to: string;
+  subject: string;
+  text?: string;
+  html?: string;
+}
+
+/**
+ * 汎用メール送信関数
+ */
+export async function sendEmail({
+  to,
+  subject,
+  text,
+  html,
+}: SendEmailParams): Promise<void> {
+  // 開発環境ではコンソールにも出力
+  if (process.env.NODE_ENV === "development") {
+    console.log("=== 📧 メール送信 ===");
+    console.log(`宛先: ${to}`);
+    console.log(`件名: ${subject}`);
+    console.log(`本文: ${text || html}`);
+    console.log("===================\n");
+  }
+
+  await transporter.sendMail({
+    from: FROM_EMAIL,
+    to,
+    subject,
+    text,
+    html,
+  });
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -101,6 +101,15 @@ export default function LoginPage() {
           </button>
         </form>
 
+        <div className="mt-4 text-center">
+          <a
+            href="/forgot-password"
+            className="text-sm text-blue-400 hover:text-blue-300 hover:underline"
+          >
+            パスワードをお忘れの方
+          </a>
+        </div>
+
         <div className="mt-6 text-center text-sm text-gray-400">
           認証コードがメールで送信されます
         </div>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, useEffect, Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import toast, { Toaster } from "react-hot-toast";
+
+function ResetPasswordForm() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    if (!token) {
+      toast.error("無効なリセットリンクです");
+      setTimeout(() => router.push("/login"), 2000);
+    }
+  }, [token, router]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (password !== confirmPassword) {
+      toast.error("パスワードが一致しません");
+      return;
+    }
+
+    if (password.length < 8) {
+      toast.error("パスワードは8文字以上である必要があります");
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch("/api/auth/password-reset/reset", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ token, password }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || "パスワードのリセットに失敗しました");
+      }
+
+      setSuccess(true);
+      toast.success(data.message || "パスワードをリセットしました");
+
+      // 3秒後にログイン画面へリダイレクト
+      setTimeout(() => router.push("/login"), 3000);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "パスワードのリセットに失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!token) {
+    return null;
+  }
+
+  if (success) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <Toaster position="top-right" />
+        <div className="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-md">
+          <div className="text-center">
+            <div className="mb-4 text-green-500 text-5xl">✓</div>
+            <h1 className="text-2xl font-bold text-white mb-4">
+              パスワードをリセットしました
+            </h1>
+            <p className="text-gray-300 mb-6">
+              新しいパスワードでログインできます。
+              <br />
+              まもなくログイン画面に移動します...
+            </p>
+            <button
+              onClick={() => router.push("/login")}
+              className="text-blue-400 hover:text-blue-300 hover:underline"
+            >
+              今すぐログイン画面へ
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-900">
+      <Toaster position="top-right" />
+      <div className="bg-gray-800 p-8 rounded-lg shadow-lg w-full max-w-md">
+        <h1 className="text-2xl font-bold text-white mb-2 text-center">
+          新しいパスワードを設定
+        </h1>
+        <p className="text-gray-400 text-sm mb-6 text-center">
+          8文字以上の英数字を含むパスワードを入力してください
+        </p>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              新しいパスワード
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              minLength={8}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor="confirmPassword"
+              className="block text-sm font-medium text-gray-300 mb-2"
+            >
+              新しいパスワード（確認）
+            </label>
+            <input
+              id="confirmPassword"
+              type="password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              required
+              minLength={8}
+              className="w-full px-3 py-2 bg-gray-700 border border-gray-600 rounded text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+              placeholder="••••••••"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white font-medium py-2 px-4 rounded transition-colors"
+          >
+            {loading ? "設定中..." : "パスワードを設定"}
+          </button>
+        </form>
+
+        <div className="mt-6 text-center">
+          <a
+            href="/login"
+            className="text-sm text-blue-400 hover:text-blue-300 hover:underline"
+          >
+            ログイン画面に戻る
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ResetPasswordPage() {
+  return (
+    <Suspense fallback={
+      <div className="min-h-screen flex items-center justify-center bg-gray-900">
+        <div className="text-white">読み込み中...</div>
+      </div>
+    }>
+      <ResetPasswordForm />
+    </Suspense>
+  );
+}


### PR DESCRIPTION
- PasswordResetTokenモデル追加（有効期限1時間、1回のみ使用可能）
- パスワードリセット要求API（メール送信）
- パスワードリセット実行API（トークン検証＋パスワード更新）
- ログイン画面に「パスワードをお忘れの方」リンク追加
- パスワード再発行画面UI作成
- パスワードリセット完了画面UI作成
- 汎用メール送信ライブラリ追加
- DEPLOYMENT.mdにSMTP設定を追記

セキュリティ:
- メールアドレスの存在確認を防ぐ
- トークンは1時間で期限切れ
- トークンは1回のみ使用可能
- パスワード強度チェック（8文字以上、英数字）

🤖 Generated with [Claude Code](https://claude.com/claude-code)