### PR TITLE
fix: GitHub ActionsでPRのベースブランチに応じたマイグレーション検出

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -42,7 +42,9 @@ jobs:
       - name: Check for new migrations
         id: check
         run: |
-          if git diff --name-only origin/main...HEAD | grep -q "prisma/migrations/"; then
+          # PRのベースブランチとの差分をチェック
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
+          if git diff --name-only origin/${BASE_REF}...HEAD | grep -q "prisma/migrations/"; then
             echo "has_migration=true" >> $GITHUB_OUTPUT
             echo "✅ 新しいマイグレーションが検出されました"
           else
@@ -54,17 +56,18 @@ jobs:
         id: diff
         if: steps.check.outputs.has_migration == 'true'
         run: |
+          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
           echo "## 📋 マイグレーション差分" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "以下のマイグレーションファイルが追加されています：" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          git diff --name-only origin/main...HEAD | grep "prisma/migrations/" | while read file; do
+          git diff --name-only origin/${BASE_REF}...HEAD | grep "prisma/migrations/" | while read file; do
             echo "- \`$file\`" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### マイグレーション内容" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          git diff --name-only origin/main...HEAD | grep "prisma/migrations/.*\.sql$" | while read file; do
+          git diff --name-only origin/${BASE_REF}...HEAD | grep "prisma/migrations/.*\.sql$" | while read file; do
             echo "<details>" >> $GITHUB_STEP_SUMMARY
             echo "<summary><code>$file</code></summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- origin/main固定ではなく、PRのベースブランチとの差分をチェック
- developへのPRでもマイグレーションが正しく検出されるように修正
- github.event.pull_request.base.refを使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)