### PR TITLE
fix: GitHub Actionsをmainブランチへのpush時のみ実行

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,10 +1,9 @@
 name: Deploy to Production
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types: [opened, synchronize, reopened]
   workflow_dispatch:
     inputs:
       skip_migration:
@@ -42,9 +41,8 @@ jobs:
       - name: Check for new migrations
         id: check
         run: |
-          # PRのベースブランチとの差分をチェック
-          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
-          if git diff --name-only origin/${BASE_REF}...HEAD | grep -q "prisma/migrations/"; then
+          # 直前のコミットとの差分をチェック（push event用）
+          if git diff --name-only HEAD~1 HEAD | grep -q "prisma/migrations/"; then
             echo "has_migration=true" >> $GITHUB_OUTPUT
             echo "✅ 新しいマイグレーションが検出されました"
           else
@@ -56,18 +54,17 @@ jobs:
         id: diff
         if: steps.check.outputs.has_migration == 'true'
         run: |
-          BASE_REF="${{ github.event.pull_request.base.ref || 'main' }}"
           echo "## 📋 マイグレーション差分" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "以下のマイグレーションファイルが追加されています：" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          git diff --name-only origin/${BASE_REF}...HEAD | grep "prisma/migrations/" | while read file; do
+          git diff --name-only HEAD~1 HEAD | grep "prisma/migrations/" | while read file; do
             echo "- \`$file\`" >> $GITHUB_STEP_SUMMARY
           done
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### マイグレーション内容" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          git diff --name-only origin/${BASE_REF}...HEAD | grep "prisma/migrations/.*\.sql$" | while read file; do
+          git diff --name-only HEAD~1 HEAD | grep "prisma/migrations/.*\.sql$" | while read file; do
             echo "<details>" >> $GITHUB_STEP_SUMMARY
             echo "<summary><code>$file</code></summary>" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## 変更内容

GitHub Actions `deploy-production.yml` のトリガーを変更：

### Before
- `pull_request` イベント: PRが `main` に作成された時点で実行
- `develop` へのマージ時も誤って実行される可能性あり

### After
- `push` イベント: `main` ブランチへマージ完了後のみ実行
- マイグレーション差分チェックを `HEAD~1 HEAD` に変更（直前のコミットとの比較）

## 影響

- `develop` ブランチへのマージでは何も起こらない
- `main` ブランチへのマージ時のみVercelデプロイが実行される
- より明確なデプロイフローになる

## 動作タイミング

1. `develop` → PR → `main` マージ → **ここでActions実行**
2. マイグレーションチェック
3. 承認（必要な場合）
4. Vercelデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)