### PR TITLE
fix: DMData.jp API認証をクエリパラメータ方式に修正

### DIFF
--- a/src/app/api/cron/fetch-earthquakes/route.ts
+++ b/src/app/api/cron/fetch-earthquakes/route.ts
@@ -36,12 +36,9 @@ async function fetchEarthquakesFromDMData() {
   url.searchParams.append("type", "VXSE51,VXSE53");
   url.searchParams.append("limit", "20");
   url.searchParams.append("order", "new");
+  url.searchParams.append("key", DMDATA_API_KEY); // クエリパラメータで認証
 
-  const response = await fetch(url.toString(), {
-    headers: {
-      Authorization: `Bearer ${DMDATA_API_KEY}`,
-    },
-  });
+  const response = await fetch(url.toString());
 
   if (!response.ok) {
     throw new Error(`DMData API error: ${response.status} ${response.statusText}`);


### PR DESCRIPTION
## 問題
cronエンドポイントが401 Unauthorizedエラーで失敗

## 原因
DMData.jp APIはAuthorizationヘッダーではなく、
クエリパラメータ `key` で認証する仕様

## 修正内容
- Authorizationヘッダー削除
- クエリパラメータに `key=DMDATA_API_KEY` を追加

## 参考
手動取得エンドポイント（/api/admin/fetch-earthquakes-now）は
正しくクエリパラメータ方式を使用していた

🤖 Generated with [Claude Code](https://claude.com/claude-code)