### PR TITLE
feat: Cron設定メニュー追加のマイグレーション

### DIFF
--- a/prisma/migrations/20251013143829_add_cron_settings_menu/migration.sql
+++ b/prisma/migrations/20251013143829_add_cron_settings_menu/migration.sql
@@ -1,0 +1,4 @@
+-- Insert Cron Settings menu
+INSERT INTO "menus" ("id", "name", "path", "icon", "display_order", "category_permission", "is_active", "created_at", "updated_at")
+VALUES (gen_random_uuid(), 'Cron設定', '/admin/cronjob-settings', 'fa-solid fa-clock', 13, 'system:admin', true, NOW(), NOW())
+ON CONFLICT ("path") DO NOTHING;


### PR DESCRIPTION
menusテーブルにCron設定レコードを追加

## マイグレーション内容

- 名前: Cron設定
- パス: /admin/cronjob-settings
- アイコン: fa-solid fa-clock
- 表示順序: 13
- 権限: system:admin

🤖 Generated with [Claude Code](https://claude.com/claude-code)