### PR TITLE
fix: Remove DIRECT_URL from Prisma schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -5,7 +5,6 @@ generator client {
 datasource db {
   provider  = "postgresql"
   url       = env("DATABASE_URL")
-  directUrl = env("DIRECT_URL")
 }
 
 model EarthquakeEventLog {


### PR DESCRIPTION
DIRECT_URL環境変数が設定されていない環境でビルドエラーになるため削除

接続プーリングのバイパスが必要な場合は、環境変数で個別に設定可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)