### PR TITLE
fix: infoType不明の地震情報を画面から除外

### DIFF
--- a/src/app/api/admin/latest-earthquakes/route.ts
+++ b/src/app/api/admin/latest-earthquakes/route.ts
@@ -11,6 +11,11 @@ export async function GET(request: NextRequest) {
     const limit = parseInt(searchParams.get("limit") || "3");
 
     const earthquakes = await prisma.earthquakeRecord.findMany({
+      where: {
+        infoType: {
+          not: "不明",
+        },
+      },
       orderBy: {
         occurrenceTime: "desc",
       },


### PR DESCRIPTION
## 変更内容

### 管理画面の地震情報表示から不明レコードを除外
- `latest-earthquakes/route.ts`: `infoType != "不明"` の条件を追加
- 情報タイプが抽出できなかった地震レコードをダッシュボードから非表示に

## 影響
- 管理画面に表示される地震情報が有効なもののみになり、視認性が向上

🤖 Generated with [Claude Code](https://claude.com/claude-code)