### PR TITLE
refactor: NEXT_PUBLIC_BASE_URLから動的にOAuth URLを生成

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -13,7 +13,6 @@ const nextConfig: NextConfig = {
   serverExternalPackages: [],
   // Provide fallback env vars for build
   env: {
-    NEXT_PUBLIC_OAUTH_REDIRECT_URI: process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI || "http://localhost:8080/oauth",
     NEXT_PUBLIC_BASE_URL: process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:8080",
   },
 };

--- a/src/app/admin/members/page.tsx
+++ b/src/app/admin/members/page.tsx
@@ -119,7 +119,7 @@ export default function MembersPage() {
 
   const copyInvitationUrl = (token: string) => {
     const baseUrl =
-      process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI || "http://localhost:3000";
+      process.env.NEXT_PUBLIC_BASE_URL || "http://localhost:8080";
     const invitationUrl = `${baseUrl}/accept-invitation?token=${token}`;
 
     if (navigator.clipboard) {

--- a/src/app/lib/env.ts
+++ b/src/app/lib/env.ts
@@ -1,10 +1,12 @@
 // src/app/lib/env.ts
+const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "http://localhost:8080";
+
 export const env = {
-  NEXT_PUBLIC_OAUTH_REDIRECT_URI:
-    process.env.NEXT_PUBLIC_OAUTH_REDIRECT_URI ?? "http://localhost:3000/oauth",
+  NEXT_PUBLIC_BASE_URL: BASE_URL,
+  NEXT_PUBLIC_OAUTH_REDIRECT_URI: `${BASE_URL}/api/admin/dmdata-oauth/callback`,
   NEXT_PUBLIC_APP_URL:
     process.env.NEXT_PUBLIC_APP_URL ??
-    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : "http://localhost:8080",
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : BASE_URL,
   DATABASE_URL:
     process.env.SUPABASE_DB_URL ??
     process.env.DATABASE_URL ??


### PR DESCRIPTION
NEXT_PUBLIC_OAUTH_REDIRECT_URIを環境変数から削除し、
NEXT_PUBLIC_BASE_URLを基にして動的に生成するように変更。

変更点:
- env.tsでBASE_URLからOAuth Redirect URIを自動生成
- next.config.tsからNEXT_PUBLIC_OAUTH_REDIRECT_URIを削除
- members/page.tsxで招待URLコピー時にBASE_URLを使用

これによりVercelで設定する環境変数が1つ削減され、
招待リンクのパスが常に正しく生成される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)