### PR TITLE
fix: Add prisma migrate deploy to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",
-    "build": "prisma generate && next build",
+    "build": "prisma generate && prisma migrate deploy && next build",
     "build:docker": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
Vercelデプロイ時に自動的にマイグレーションを実行するよう修正。
これにより、本番環境でInternal Server Errorが発生する問題を解決。

Changes:
- build script に "prisma migrate deploy" を追加
- デプロイ時に未適用のマイグレーションが自動適用される

🤖 Generated with [Claude Code](https://claude.com/claude-code)