### PR TITLE
fix: Fix migration issues and add user:read permission

### DIFF
--- a/prisma/migrations/20251022143800_add_user_read_permission/migration.sql
+++ b/prisma/migrations/20251022143800_add_user_read_permission/migration.sql
@@ -1,35 +1,35 @@
--- Add member:invite permission
+-- Add user:read permission
 INSERT INTO permissions (id, name, display_name, description, category, created_at, updated_at)
 VALUES (
   gen_random_uuid(),
-  'member:invite',
-  'メンバー招待',
-  '新しいメンバーを招待する権限',
-  'member',
+  'user:read',
+  'ユーザー閲覧',
+  'ユーザー情報の閲覧',
+  'user',
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP
 )
 ON CONFLICT (name) DO NOTHING;
 
--- Attach member:invite permission to ADMIN group
+-- Attach user:read permission to ADMIN group
 DO $$
 DECLARE
     admin_group_id TEXT;
-    invite_permission_id TEXT;
+    user_read_permission_id TEXT;
 BEGIN
     -- Get ADMIN group ID
     SELECT id INTO admin_group_id FROM groups WHERE name = '管理者グループ' AND is_system = true LIMIT 1;
 
-    -- Get member:invite permission ID
-    SELECT id INTO invite_permission_id FROM permissions WHERE name = 'member:invite' LIMIT 1;
+    -- Get user:read permission ID
+    SELECT id INTO user_read_permission_id FROM permissions WHERE name = 'user:read' LIMIT 1;
 
     -- If both exist, attach permission to group
-    IF admin_group_id IS NOT NULL AND invite_permission_id IS NOT NULL THEN
+    IF admin_group_id IS NOT NULL AND user_read_permission_id IS NOT NULL THEN
         INSERT INTO group_permission_attachments (id, group_id, permission_id, created_at)
         VALUES (
             gen_random_uuid(),
             admin_group_id,
-            invite_permission_id,
+            user_read_permission_id,
             CURRENT_TIMESTAMP
         )
         ON CONFLICT (group_id, permission_id) DO NOTHING;

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -502,6 +502,14 @@ async function main() {
       category: "message",
     },
 
+    // ユーザー管理
+    {
+      name: "user:read",
+      displayName: "ユーザー閲覧",
+      description: "ユーザー情報の閲覧",
+      category: "user",
+    },
+
     // メンバー管理
     {
       name: "member:read",


### PR DESCRIPTION
マイグレーションの問題を修正し、user:read権限を追加。

Changes:
- Fix add_group_to_invitation migration to handle existing NULL values
- Fix group_permission_attachments INSERT (remove non-existent updated_at column)
- Fix ADMIN group name in member:invite migration
- Add user:read permission for /api/users endpoint access
- Update seed.ts to include user:read permission

🤖 Generated with [Claude Code](https://claude.com/claude-code)